### PR TITLE
ci: relax normative block enforcement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 ### Objet de la modification
 ...
 
-### Référence normative (OBLIGATOIRE)
+### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
+> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`.
 - Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) :
 - Section/Clause/Entrée :
 - Lien public / identifiant :

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -21,6 +21,21 @@ jobs:
               core.info('No pull request payload detected; skipping normative reference check.');
               return;
             }
+            const { owner, repo } = context.repo;
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              },
+            );
+            const touchesNormative = files.some((file) => /^(templates|standards)\//.test(file.filename));
+            if (!touchesNormative) {
+              core.info('No templates/standards files changed; skipping normative block enforcement.');
+              return;
+            }
             const body = pr.body || "";
             const ok = /Référence normative.*(ISO|ISTQB|IEEE|IREB|25010|29119)/i.test(body);
             if (!ok) core.setFailed("La PR doit contenir un bloc 'Référence normative'.");

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 1. **Docs CI** doit être verte :
    - `markdownlint`.
    - `Vale` (style `Fr`, dictionnaire hunspell).
-   - Script `Référence normative` (appliqué aux PR modifiant templates/docs normatifs).
+   - Script `Référence normative` (seulement si la PR modifie `templates/` ou `standards/`; sinon, indiquer `N/A` dans le template de PR).
 2. **Branch protection** :
    - Historique linéaire.
    - Conversations résolues.

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4235
+4239
 A
 a
 AAAA-MM-JJ
@@ -4234,3 +4234,7 @@ supprimer
 Toilettage
 verte
 brouillon
+indiquer
+Indiquer
+modifie
+seulement

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4233,3 +4233,7 @@ supprimer
 Toilettage
 verte
 brouillon
+indiquer
+Indiquer
+modifie
+seulement


### PR DESCRIPTION
Référence normative : N/A (pas de modification de templates/standards)

### Objet de la modification
- Adapter `Docs CI` pour ne contrôler le bloc normatif que lorsque des fichiers `templates/` ou `standards/` changent.
- Mettre à jour le template de PR et le guide de contribution pour refléter la nouvelle règle.

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : N/A
- Section/Clause/Entrée : N/A
- Lien public / identifiant : N/A

### Justification (résumé)
Éviter des échecs de CI inutiles pour les PR tooling/docs tout en conservant l’exigence pour les mises à jour normatives.

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #37
