### PR TITLE
governance: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS
+# Maintains review ownership by area
+
+# Templates and standards must be reviewed by the maintainer
+/templates/ @EdouardZemb
+/standards/ @EdouardZemb
+/docs/ @EdouardZemb
+/styles/ @EdouardZemb
+
+# CI and governance files
+/.github/ @EdouardZemb


### PR DESCRIPTION
Référence normative : N/A (pas de modification `templates/` ou `standards/`)

### Objet de la modification
- Ajouter `.github/CODEOWNERS` pour imposer la revue du mainteneur sur templates, standards, docs, styles et automatisations.

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : N/A
- Section/Clause/Entrée : N/A
- Lien public / identifiant : N/A

### Justification (résumé)
Automatiser l’assignation des revues conformément au guide de contribution et à la branch protection.

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #5
