### PR TITLE
feat(standards): whitelist normative references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS
+# Maintains review ownership by area
+
+# Templates and standards must be reviewed by the maintainer
+/templates/ @EdouardZemb
+/standards/ @EdouardZemb
+/docs/ @EdouardZemb
+/styles/ @EdouardZemb
+
+# CI and governance files
+/.github/ @EdouardZemb

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 ...
 
 ### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
-> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`.
+> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
 - Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) :
 - Section/Clause/Entrée :
 - Lien public / identifiant :

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -36,6 +36,88 @@ jobs:
               core.info('No templates/standards files changed; skipping normative block enforcement.');
               return;
             }
+            const fs = require('fs');
+            const path = require('path');
+            const yamlPath = path.join(process.cwd(), 'standards', 'references.yaml');
+            if (!fs.existsSync(yamlPath)) {
+              core.setFailed('standards/references.yaml introuvable.');
+              return;
+            }
+            const yamlText = fs.readFileSync(yamlPath, 'utf8');
+            const references = [];
+            let current = null;
+            let collectingTokens = false;
+            for (const rawLine of yamlText.split(/\r?\n/)) {
+              const line = rawLine.replace(/\t/g, '    ');
+              const trimmed = line.trim();
+              if (!trimmed || trimmed.startsWith('#')) {
+                continue;
+              }
+              if (trimmed.startsWith('- key:')) {
+                if (current) {
+                  references.push(current);
+                }
+                current = { tokens: [] };
+                collectingTokens = false;
+                current.key = trimmed.replace('- key:', '').trim();
+                continue;
+              }
+              if (!current) {
+                continue;
+              }
+              const keyValue = line.match(/^\s+(\w+):\s*(.*)$/);
+              if (keyValue) {
+                const field = keyValue[1];
+                let value = keyValue[2].trim();
+                value = value.replace(/^"/, '').replace(/"$/, '');
+                if (field === 'tokens') {
+                  collectingTokens = true;
+                  if (!current.tokens) {
+                    current.tokens = [];
+                  }
+                } else {
+                  collectingTokens = false;
+                  current[field] = value;
+                }
+                continue;
+              }
+              if (collectingTokens) {
+                const tokenMatch = line.match(/^\s*-\s*(.*)$/);
+                if (tokenMatch) {
+                  let token = tokenMatch[1].trim();
+                  token = token.replace(/^"/, '').replace(/"$/, '');
+                  current.tokens.push(token);
+                }
+              }
+            }
+            if (current) {
+              references.push(current);
+            }
+            const tokens = references.flatMap((ref) => {
+              const list = [];
+              if (ref.key) list.push(ref.key);
+              if (ref.identifier) list.push(ref.identifier);
+              if (ref.title) list.push(ref.title);
+              if (Array.isArray(ref.tokens)) list.push(...ref.tokens);
+              return list;
+            }).map((token) => token.toLowerCase());
+            if (!tokens.length) {
+              core.setFailed('Aucune référence définie dans standards/references.yaml.');
+              return;
+            }
             const body = pr.body || "";
-            const ok = /Référence normative.*(ISO|ISTQB|IEEE|IREB|25010|29119)/i.test(body);
-            if (!ok) core.setFailed("La PR doit contenir un bloc 'Référence normative'.");
+            const sectionMatch = body.match(/### Référence normative[\s\S]*?(?=### |$)/i);
+            const normativeSection = sectionMatch ? sectionMatch[0].toLowerCase() : '';
+            if (!normativeSection.trim()) {
+              core.setFailed("Le bloc 'Référence normative' est requis pour les modifications templates/standards.");
+              return;
+            }
+            const hasNA = normativeSection.includes('n/a');
+            const mentionsReference = tokens.some((token) => token && normativeSection.includes(token));
+            if (!mentionsReference) {
+              if (hasNA) {
+                core.setFailed("Pour les modifications templates/standards, la section 'Référence normative' doit citer une source présente dans standards/references.yaml (N/A n'est pas accepté).");
+              } else {
+                core.setFailed("La section 'Référence normative' doit citer au moins une référence listée dans standards/references.yaml.");
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 1. **Docs CI** doit être verte :
    - `markdownlint`.
    - `Vale` (style `Fr`, dictionnaire hunspell).
-   - Script `Référence normative` (seulement si la PR modifie `templates/` ou `standards/`; sinon, indiquer `N/A` dans le template de PR).
+   - Script `Référence normative` (seulement si la PR modifie `templates/` ou `standards/`; citer au moins une entrée de `standards/references.yaml`, sinon indiquer `N/A`).
 2. **Branch protection** :
    - Historique linéaire.
    - Conversations résolues.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ce dépôt fournit des modèles de documentation de test alignés ISO/IEC/IEEE 2
   - `08-Rapport-Statut-de-test.md` – suivi d'avancement.
   - `09-Rapport-Cloture-de-test.md` – bilan et critères de sortie.
 - `styles/` — configuration Vale (dictionnaire français, règles `Fr.Spelling`).
-- `standards/` — à compléter avec glossaires et listes normatives (#10, #9).
+- `standards/` — références normatives (`references.yaml`) et futurs glossaires (issues #9, #10).
 - `docs/` — guides d'adoption et usage (#29).
 - `decisions/` — journal des Decision Records (DR) futur (#7, #30).
 
@@ -53,7 +53,7 @@ Conventions : commits en anglais (`conventional commits`), décisions structuré
 - ISO/IEC 25010 (modèle de qualité / NFR).
 - ISTQB® Glossary 4.0.
 - IEEE 1012 (V&V) — en préparation.
-- Fichier `standards/references.yaml` à créer (#9) pour centraliser les identifiants utilisés dans les PR et documents.
+- Fichier `standards/references.yaml` pour centraliser les identifiants utilisés dans les PR et documents.
 
 ## Feuille de route
 

--- a/standards/references.yaml
+++ b/standards/references.yaml
@@ -1,0 +1,49 @@
+# Liste blanche des références normatives autorisées
+# Chaque entrée fournit une clé stable, un titre, un identifiant officiel et un lien public.
+- key: iso29119-2
+  title: "ISO/IEC/IEEE 29119-2:2021 — Software and systems engineering — Software testing — Part 2: Test processes"
+  identifier: "ISO/IEC/IEEE 29119-2:2021"
+  link: "https://www.iso.org/standard/45183.html"
+  tokens:
+    - "ISO/IEC/IEEE 29119-2"
+    - "ISO 29119-2"
+    - "29119-2"
+- key: iso29119-3
+  title: "ISO/IEC/IEEE 29119-3:2021 — Software and systems engineering — Software testing — Part 3: Test documentation"
+  identifier: "ISO/IEC/IEEE 29119-3:2021"
+  link: "https://www.iso.org/standard/45184.html"
+  tokens:
+    - "ISO/IEC/IEEE 29119-3"
+    - "ISO 29119-3"
+    - "29119-3"
+- key: iso25010
+  title: "ISO/IEC 25010:2011 — Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — System and software quality models"
+  identifier: "ISO/IEC 25010:2011"
+  link: "https://www.iso.org/standard/35733.html"
+  tokens:
+    - "ISO/IEC 25010"
+    - "ISO 25010"
+    - "25010"
+- key: istqb-glossary
+  title: "ISTQB® Glossary of Testing Terms v4.0"
+  identifier: "ISTQB Glossary 4.0"
+  link: "https://glossary.istqb.org/"
+  tokens:
+    - "ISTQB"
+    - "ISTQB Glossary"
+    - "ISTQB® Glossary"
+- key: ieee-1012
+  title: "IEEE Std 1012-2016 — IEEE Standard for System, Software, and Hardware Verification and Validation"
+  identifier: "IEEE 1012:2016"
+  link: "https://standards.ieee.org/ieee/1012/6786/"
+  tokens:
+    - "IEEE 1012"
+    - "IEEE Std 1012"
+    - "IEEE 1012:2016"
+- key: ireb-cpre
+  title: "IREB Certified Professional for Requirements Engineering (CPRE) — Syllabi"
+  identifier: "IREB CPRE"
+  link: "https://www.ireb.org/en/service/downloads/"
+  tokens:
+    - "IREB"
+    - "IREB CPRE"

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4239
+4240
 A
 a
 AAAA-MM-JJ
@@ -4238,3 +4238,4 @@ indiquer
 Indiquer
 modifie
 seulement
+futurs

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4237,3 +4237,4 @@ indiquer
 Indiquer
 modifie
 seulement
+futurs


### PR DESCRIPTION
Référence normative : ISO/IEC/IEEE 29119-2:2021; ISO/IEC/IEEE 29119-3:2021

### Objet de la modification
- Ajouter `standards/references.yaml` pour lister les sources normatives autorisées.
- Mettre à jour la CI et la documentation afin d’exiger que les PR templates/standards citent une référence de cette liste.

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : ISO/IEC/IEEE 29119-2:2021; ISO/IEC/IEEE 29119-3:2021
- Section/Clause/Entrée : Processus (Part 2 §4-5); Documentation (Part 3 Annex A)
- Lien public / identifiant : https://www.iso.org/standard/45183.html / https://www.iso.org/standard/45184.html

### Justification (résumé)
Garantir une liste blanche de références et empêcher des citations hors périmètre via une validation CI.

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #9
