### PR TITLE
docs(governance): define identifier conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 
 - Normes supportées : ISO/IEC/IEEE 29119-2/-3, ISO/IEC 25010, ISTQB Glossary, IEEE 1012.
 - Les documents doivent citer les sources dans leur front matter ou dans la PR (voir `standards/references.yaml` et `standards/glossaire-istqb.md`).
+- Respecter les conventions d'identifiants décrites dans `standards/conventions-identifiants.md`.
 - Toute décision structurante est documentée via un Decision Record (`decisions/`).
 
 En suivant ce flux, chaque contribution reste traçable, normée et mergeable sans surprise.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ce dépôt fournit des modèles de documentation de test alignés ISO/IEC/IEEE 2
   - `08-Rapport-Statut-de-test.md` – suivi d'avancement.
   - `09-Rapport-Cloture-de-test.md` – bilan et critères de sortie.
 - `styles/` — configuration Vale (dictionnaire français, règles `Fr.Spelling`).
-- `standards/` — références normatives (`references.yaml`), glossaires (`glossaire-istqb.md`) et cartographie NFR (`cartographie-nfr-iso25010.md`).
+- `standards/` — références normatives (`references.yaml`), glossaires (`glossaire-istqb.md`) et conventions (NFR `cartographie-nfr-iso25010.md`, identifiants `conventions-identifiants.md`).
 - `docs/` — guides d'adoption et usage (#29).
 - `decisions/` — journal des Decision Records (DR) futur (#7, #30).
 

--- a/standards/conventions-identifiants.md
+++ b/standards/conventions-identifiants.md
@@ -1,0 +1,37 @@
+---
+title: "Conventions d'identifiants"
+source: "Projet internalisé — aligné ISO/IEC/IEEE 29119 & ISTQB"
+last_updated: "2025-10-06"
+---
+
+> Règles de nommage pour les artefacts de test et la gouvernance associée. Format général : `PREFIX-Contexte-NNN`, où `PREFIX` est imposé, `Contexte` est un code lisible (ex. domaine, lot, feature) et `NNN` un compteur numérique sur 3 chiffres (`001`, `002`, ...). Utiliser des majuscules et le trait d'union comme séparateur.
+
+## Tableau des préfixes
+
+| Préfixe | Artefact | Regex recommandée | Exemple |
+| ------- | -------- | ----------------- | ------- |
+| `TCN` | Condition de test | `^TCN-[A-Z0-9]+-\d{3}$` | `TCN-CART-005` |
+| `TCS` | Cas de test | `^TCS-[A-Z0-9]+-\d{3}$` | `TCS-CHECKOUT-012` |
+| `TPS` | Procédure de test | `^TPS-[A-Z0-9]+-\d{3}$` | `TPS-REGRESSION-001` |
+| `DT`  | Jeu de données (Data Test) | `^DT-[A-Z0-9]+-\d{3}$` | `DT-PAIEMENT-003` |
+| `ENV` | Environnement de test | `^ENV-[A-Z0-9]+-\d{2}$` | `ENV-STG-01` |
+| `REQ` | Exigence fonctionnelle/NFR | `^REQ-[A-Z0-9]+-\d{3}$` | `REQ-SECURITY-010` |
+| `RSK` | Risque produit/projet | `^RSK-[A-Z0-9]+-\d{3}$` | `RSK-PROD-002` |
+| `DR`  | Decision Record (gouvernance) | `^DR-\d{4}-\d{2}$` | `DR-2025-01` |
+
+### Précisions
+
+- **Contexte** (`[A-Z0-9]+`) : privilégier un code court (2-10 caractères) reflétant le périmètre (ex. `AUTH`, `DATA`, `OPS`).
+- **Compteur** : démarrer à `001` (ou `01` selon regex) et incrémenter séquentiellement pour chaque nouveau document.
+- **DR** : format date + incrément pour s'aligner sur les pratiques de registre de decisions.
+
+## Bonnes pratiques
+
+1. Documenter les codes de contexte utilisés dans la stratégie ou le plan de test pour garantir la cohérence.
+2. Mettre à jour les matrices de traçabilité (ex. `REQ` ↔ `TCS`) en conservant ces identifiants.
+3. Vérifier les identifiants lors des revues PR et dans la CI (à compléter via issue #26 pour une validation regex automatique).
+
+## Références
+
+- `standards/references.yaml` — ISO/IEC/IEEE 29119 pour la structuration documentaire.
+- `standards/glossaire-istqb.md` — Terminologie associée.

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4296
+4307
 A
 a
 AAAA-MM-JJ
@@ -4295,3 +4295,14 @@ Traduire
 traiter
 utilisateur
 XConnect
+Bonnes
+chiffres
+Compteur
+compteur
+conservant
+documentaire
+garantir
+lisible
+majuscules
+pratiques
+structuration

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4294,3 +4294,14 @@ Traduire
 traiter
 utilisateur
 XConnect
+Bonnes
+chiffres
+Compteur
+compteur
+conservant
+documentaire
+garantir
+lisible
+majuscules
+pratiques
+structuration

--- a/templates/01-Strategie-de-test.md
+++ b/templates/01-Strategie-de-test.md
@@ -236,3 +236,5 @@ licence: "CC BY 4.0"
 | ------: | -------------- | ------- | ------------------- |
 | `0.1.0` | `<AAAA-MM-JJ>` | `<Nom>` | Création du modèle. |
 
+
+* Conventions d'identifiants : `standards/conventions-identifiants.md`

--- a/templates/02-Plan-de-test.md
+++ b/templates/02-Plan-de-test.md
@@ -41,6 +41,7 @@ licence: "CC BY 4.0"
 ## 2. Références & artefacts liés
 
 * Cartographie NFR : `standards/cartographie-nfr-iso25010.md`
+* Conventions d'identifiants : `standards/conventions-identifiants.md`
 
 * **Stratégie de test** (01) : `<lien>`
 * **Spécification de conception** (03) : `<lien>`

--- a/templates/03-Spec-Conception-de-test.md
+++ b/templates/03-Spec-Conception-de-test.md
@@ -45,6 +45,7 @@ licence: "CC BY 4.0"
 * Normes et référentiels : `ISO 29119-3`, `ISTQB Glossary`, `ISO 25010`, autres : `<…>`
 * Glossaire ISTQB : `standards/glossaire-istqb.md`
 * Cartographie NFR : `standards/cartographie-nfr-iso25010.md`
+* Conventions d'identifiants : `standards/conventions-identifiants.md`
 
 <!-- Saisir ici, si connu, les clauses/sections normatives précises qui motivent un choix de conception. -->
 

--- a/templates/04-Spec-Cas-de-test.md
+++ b/templates/04-Spec-Cas-de-test.md
@@ -54,6 +54,8 @@ licence: "CC BY 4.0"
 * **Environnements** : `ENV-<code>` (cf. référentiel d'envs du projet).
 * **Traçabilité** : chaque cas **doit** référencer ≥1 **condition de test** `TCN-…` et, si possible, les **exigences** `REQ-…`.
 
+> Consulter `standards/conventions-identifiants.md` pour les préfixes (`TCS`, `TCN`, `TPS`, `DT`, etc.).
+
 ---
 
 ## 4. Registre des cas de test (vue synthèse)

--- a/templates/08-Rapport-Statut-de-test.md
+++ b/templates/08-Rapport-Statut-de-test.md
@@ -213,3 +213,5 @@ licence: "CC BY 4.0"
 | ------: | -------------- | ------- | ------------------- |
 | `0.1.0` | `<AAAA-MM-JJ>` | `<Nom>` | Création du modèle. |
 
+
+* Conventions d'identifiants : `standards/conventions-identifiants.md`


### PR DESCRIPTION
Référence normative : ISO/IEC/IEEE 29119-3:2021; ISTQB Glossary 4.0

### Objet de la modification
- Documenter les préfixes d'identifiants (`TCN`, `TCS`, `TPS`, `DT`, `ENV`, `REQ`, `RSK`, `DR`) avec regex et exemples.
- Référencer cette convention dans les templates, le README et le guide de contribution.

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : ISO/IEC/IEEE 29119-3:2021; ISTQB Glossary 4.0
- Section/Clause/Entrée : ISO 29119-3 Annex A (structure documentaire); Glossary entry “test case”, “test data”, etc.
- Lien public / identifiant : https://www.iso.org/standard/45184.html / https://glossary.istqb.org/

### Justification (résumé)
Harmoniser les identifiants des artefacts de test et faciliter la traçabilité.

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #6
