### PR TITLE
docs(release): document unified release lifecycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 3. **Nettoyage** : supprimer la branche distante (`Delete branch`), archiver la branche locale.
 4. **Release** (si applicable) :
    - Ajouter un tag sémantique.
-   - Mettre à jour le changelog / notes de release.
+   - Mettre à jour le changelog / notes de release (cf. `docs/release-lifecycle.md`).
    - Les liens Issue ↔ PR ↔ commit assurent la traçabilité.
 
 ## 6. Automatisations & templates

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -37,5 +37,6 @@ Cette page décrit les rôles, responsabilités et processus de décision pour l
 - `standards/references.yaml` : sources normatives autorisées.
 - `standards/glossaire-istqb.md` & `standards/cartographie-nfr-iso25010.md` : ressources de référence.
 - `standards/conventions-identifiants.md` : préfixes d’artefacts.
+- `docs/release-lifecycle.md` : cycle release, milestones, checklist.
 
 Toute évolution du processus doit être discutée via issue + PR associées. Lorsque des rôles supplémentaires sont nommés ou que les règles de revue évoluent, ce document constitue la référence officielle.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ce dépôt fournit des modèles de documentation de test alignés ISO/IEC/IEEE 2
   - `09-Rapport-Cloture-de-test.md` – bilan et critères de sortie.
 - `styles/` — configuration Vale (dictionnaire français, règles `Fr.Spelling`).
 - `standards/` — références normatives (`references.yaml`), glossaires (`glossaire-istqb.md`) et conventions (NFR `cartographie-nfr-iso25010.md`, identifiants `conventions-identifiants.md`).
-- `docs/` — guides d'adoption et usage (#29).
+- `docs/` — guides (adoption, release lifecycle, etc.).
 - `decisions/` — journal des Decision Records (DR) futur (#7, #30).
 
 ## Outillage & CI

--- a/docs/release-lifecycle.md
+++ b/docs/release-lifecycle.md
@@ -1,0 +1,76 @@
+# Release lifecycle & milestones
+
+Ce guide formalise la gestion d'une release pour **testing-templates** : planification via milestones, stabilisation (release candidate) et publication (notes de version, tags).
+
+## 1. Cycle général
+
+1. **Planification**
+   - Créer/mettre à jour un milestone (`vX.Y.Z`) avec la date cible.
+   - Ajouter les issues priorisées (cf. `governance: define backlog prioritization strategy` #64) en vérifiant leur DoR (#56).
+2. **Développement**
+   - Issues en colonne "In Progress" du board (#63) et PR associées.
+   - CI (`Docs CI`) doit rester verte; Vale/markdownlint obligatoires.
+3. **Stabilisation (RC)**
+   - Geler le scope du milestone.
+   - Exécuter la checklist de release (voir ci-dessous) incluant tests complémentaires/manuels si nécessaire.
+   - Créer une branche `release/vX.Y.Z-rc` optionnelle pour les retouches.
+4. **Publication**
+   - Merging des PR restantes après review (au moins 1 review mainteneur, se synchronise avec `GOVERNANCE.md`).
+   - Créer le tag `vX.Y.Z` sur `main`.
+   - Générer les notes de version (CHANGELOG ou GitHub Release) et communiquer.
+5. **Post-release**
+   - Déplacer le milestone en "Closed".
+   - Créer le milestone suivant.
+
+## 2. Checklist release
+
+Avant de tagger `vX.Y.Z`, cocher :
+
+- [ ] Toutes les issues du milestone sont `Done` ou déplacées vers un autre milestone.
+- [ ] `CONTRIBUTING.md`, `GOVERNANCE.md` et `standards/*` reflètent les nouveautés.
+- [ ] Licence/nores normatives inchangées ou mises à jour (#47/#48 le cas échéant).
+- [ ] Dépendances critiques vérifiées (#61).
+- [ ] Templates lintés (`vale`, `markdownlint`) localement.
+- [ ] Notes de version préparées (voir modèle ci-dessous).
+
+## 3. Milestones GitHub
+
+- Utiliser les milestones comme jalon principal (ex. `v0.1.0 — Initialisation`).
+- À l'ouverture d'une issue, définir son milestone si elle vise la release en cours.
+- En revue hebdomadaire, vérifier l'avancement du milestone (#63/board).
+
+## 4. Release notes
+
+Modèle Github Release / CHANGELOG :
+
+```
+## vX.Y.Z – yyyy-mm-dd
+
+### Nouveautés
+- …
+
+### Gouvernance
+- …
+
+### Normes
+- …
+
+### Remarques
+- …
+```
+
+Ajouter une section "Crédits" si contribution externe.
+
+## 5. Communication
+
+- Publier les notes de version sur GitHub.
+- Diffuser (mail/Slack interne) un court résumé avec lien vers la release et issues.
+- Mettre en évidence les changements de gouvernance (ex. nouveaux DR, politiques).
+
+## 6. Références
+
+- Issue #62 – cadre unifié (ce document).
+- Issue #27 – workflow & changelog (remplacé).
+- Issue #52 – milestones (intégré).
+- Issue #53 – stabilisation & publication (intégré).
+- `LICENSE`, `GOVERNANCE.md`, `CONTRIBUTING.md`.

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4314
+4326
 A
 a
 AAAA-MM-JJ
@@ -4313,3 +4313,15 @@ structurantes
 suffit
 Veille
 verts
+ajouter
+Ajouter
+cocher
+externe
+Github
+github
+hebdomadaire
+incluant
+optionnelle
+Publier
+publier
+restantes

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4312,3 +4312,15 @@ structurantes
 suffit
 Veille
 verts
+ajouter
+Ajouter
+cocher
+externe
+Github
+github
+hebdomadaire
+incluant
+optionnelle
+Publier
+publier
+restantes


### PR DESCRIPTION
Référence normative : N/A (processus interne)

### Objet de la modification
- Créer `docs/release-lifecycle.md` consolidant la planification par milestones, la stabilisation (RC) et la publication (notes de version).
- Lier ce guide dans `CONTRIBUTING.md` et `GOVERNANCE.md` (via sections déjà en place).

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : N/A
- Section/Clause/Entrée : N/A
- Lien public / identifiant : N/A

### Justification (résumé)
Aligner les sous-issues #52, #53, #27 en un seul cadre release (milestones, RC, notes).

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #62
