### PR TITLE
ci: validate standards/references.yaml

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Validate references.yaml
+        run: python3 scripts/validate_references.py
       - uses: DavidAnson/markdownlint-cli2-action@v20
       - uses: errata-ai/vale-action@v2.1.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 - **Security** : pour signaler un problème, suivre `SECURITY.md`.
 - **PR Template** : `.github/PULL_REQUEST_TEMPLATE.md` avec bloc `Référence normative`.
 - **CI** : `.github/workflows/docs-ci.yml` (markdownlint + Vale + contrôle PR).
+- **Validation références** : `scripts/validate_references.py` (via Docs CI).
 - **Vale** : `.vale.ini`, style `styles/Fr/`, dictionnaire `styles/Fr/dictionaries/fr.dic`.
 - **Branch naming** et **Draft PR** : requis pour tous les contributeurs.
 

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+YAML_PATH = Path('standards/references.yaml')
+REQUIRED_FIELDS = {"key", "title", "identifier", "link", "tokens"}
+ALLOWED_STATUS = {"published", "withdrawn", "superseded", "draft", "deprecated"}
+
+pattern_entry = re.compile(r'^-\s+key:\s*(.*)$')
+pattern_field = re.compile(r'^\s{2}([a-zA-Z_]+):\s*(.*)$')
+pattern_token = re.compile(r'^\s{4}-\s*(.*)$')
+
+errors = []
+entries = []
+
+if not YAML_PATH.exists():
+    errors.append("standards/references.yaml introuvable")
+else:
+    current = None
+    for raw in YAML_PATH.read_text().splitlines():
+        if not raw.strip() or raw.strip().startswith('#'):
+            continue
+        m_entry = pattern_entry.match(raw)
+        if m_entry:
+            if current:
+                entries.append(current)
+            current = {"tokens": []}
+            current['key'] = m_entry.group(1).strip('"')
+            continue
+        if current is None:
+            continue
+        m_field = pattern_field.match(raw)
+        if m_field:
+            field, value = m_field.groups()
+            value = value.strip()
+            if field == 'tokens':
+                current['tokens'] = []
+            elif value:
+                current[field] = value.strip('"')
+            else:
+                current[field] = ""
+            continue
+        m_token = pattern_token.match(raw)
+        if m_token:
+            token = m_token.group(1).strip().strip('"')
+            current.setdefault('tokens', []).append(token)
+            continue
+    if current:
+        entries.append(current)
+
+    seen = set()
+    for idx, entry in enumerate(entries, 1):
+        missing = REQUIRED_FIELDS - entry.keys()
+        if missing:
+            errors.append(f"Entrée #{idx} (key={entry.get('key')}) : champs manquants {sorted(missing)}")
+        key = entry.get('key')
+        if key in seen:
+            errors.append(f"Clé dupliquée : {key}")
+        else:
+            seen.add(key)
+        link = entry.get('link')
+        if link and not link.startswith('http'):
+            errors.append(f"Entrée {key} : lien invalide {link}")
+        status = entry.get('status')
+        if status and status not in ALLOWED_STATUS:
+            errors.append(f"Entrée {key} : statut '{status}' non reconnu. Autorisés: {sorted(ALLOWED_STATUS)}")
+        if not isinstance(entry.get('tokens'), list):
+            errors.append(f"Entrée {key} : 'tokens' doit être une liste")
+
+if errors:
+    for err in errors:
+        print(f"::error::{err}")
+    raise SystemExit(1)
+
+print("Validation de standards/references.yaml OK")


### PR DESCRIPTION
Référence normative : ISO/IEC/IEEE 29119-3:2021

### Objet de la modification
- Ajouter `scripts/validate_references.py` pour valider `standards/references.yaml` (structure, doublons, liens, statut).
- Intégrer ce script dans `Docs CI` et documenter la règle dans CONTRIBUTING.

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : ISO/IEC/IEEE 29119-3:2021
- Section/Clause/Entrée : Documentation (Part 3)
- Lien public / identifiant : https://www.iso.org/standard/79429.html

### Justification (résumé)
Automatiser la vérification des références normatives (#49) pour éviter les erreurs de saisie.

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #49
