### PR TITLE
docs(standards): track reference lifecycle status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 - **Security** : pour signaler un problème, suivre `SECURITY.md`.
 - **PR Template** : `.github/PULL_REQUEST_TEMPLATE.md` avec bloc `Référence normative`.
 - **CI** : `.github/workflows/docs-ci.yml` (markdownlint + Vale + contrôle PR).
-- **Validation références** : `scripts/validate_references.py` (via Docs CI).
+- **Validation références** : `scripts/validate_references.py` (via Docs CI).   Inclure obligatoirement le champ `status` (ex.: `published`).
 - **Vale** : `.vale.ini`, style `styles/Fr/`, dictionnaire `styles/Fr/dictionaries/fr.dic`.
 - **Branch naming** et **Draft PR** : requis pour tous les contributeurs.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Conventions : commits en anglais (`conventional commits`), décisions structuré
 - ISO/IEC 25010 (modèle de qualité / NFR).
 - ISTQB® Glossary 4.0 (cf. `standards/glossaire-istqb.md`).
 - IEEE 1012 (V&V) — en préparation.
-- Fichier `standards/references.yaml` pour centraliser les identifiants utilisés dans les PR et documents.
+- Fichier `standards/references.yaml` (avec champ `status`) pour centraliser les identifiants utilisés dans les PR et documents.
 
 ## Feuille de route
 

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 YAML_PATH = Path('standards/references.yaml')
-REQUIRED_FIELDS = {"key", "title", "identifier", "link", "tokens"}
+REQUIRED_FIELDS = {"key", "title", "identifier", "link", "tokens", "status"}
 ALLOWED_STATUS = {"published", "withdrawn", "superseded", "draft", "deprecated"}
 
 pattern_entry = re.compile(r'^-\s+key:\s*(.*)$')

--- a/standards/references.yaml
+++ b/standards/references.yaml
@@ -3,6 +3,7 @@
 - key: iso29119-2
   title: "ISO/IEC/IEEE 29119-2:2021 — Software and systems engineering — Software testing — Part 2: Test processes"
   identifier: "ISO/IEC/IEEE 29119-2:2021"
+  status: "published"
   link: "https://www.iso.org/standard/45183.html"
   tokens:
     - "ISO/IEC/IEEE 29119-2"
@@ -11,6 +12,7 @@
 - key: iso29119-3
   title: "ISO/IEC/IEEE 29119-3:2021 — Software and systems engineering — Software testing — Part 3: Test documentation"
   identifier: "ISO/IEC/IEEE 29119-3:2021"
+  status: "published"
   link: "https://www.iso.org/standard/79429.html"
   tokens:
     - "ISO/IEC/IEEE 29119-3"
@@ -19,6 +21,7 @@
 - key: iso25010
   title: "ISO/IEC 25010:2011 — Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — System and software quality models"
   identifier: "ISO/IEC 25010:2011"
+  status: "published"
   link: "https://www.iso.org/standard/35733.html"
   tokens:
     - "ISO/IEC 25010"
@@ -27,6 +30,7 @@
 - key: istqb-glossary
   title: "ISTQB® Glossary of Testing Terms v4.0"
   identifier: "ISTQB Glossary 4.0"
+  status: "published"
   link: "https://glossary.istqb.org/"
   tokens:
     - "ISTQB"
@@ -35,6 +39,7 @@
 - key: ieee-1012
   title: "IEEE Std 1012-2016 — IEEE Standard for System, Software, and Hardware Verification and Validation"
   identifier: "IEEE 1012:2016"
+  status: "published"
   link: "https://standards.ieee.org/ieee/1012/6786/"
   tokens:
     - "IEEE 1012"
@@ -43,6 +48,7 @@
 - key: ireb-cpre
   title: "IREB Certified Professional for Requirements Engineering (CPRE) — Syllabi"
   identifier: "IREB CPRE"
+  status: "published"
   link: "https://www.ireb.org/en/service/downloads/"
   tokens:
     - "IREB"

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4350
+4353
 A
 a
 AAAA-MM-JJ
@@ -4349,3 +4349,6 @@ pouvons
 prenons
 publique
 utilisez
+inclure
+Inclure
+obligatoirement

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4348,3 +4348,6 @@ pouvons
 prenons
 publique
 utilisez
+inclure
+Inclure
+obligatoirement


### PR DESCRIPTION
Référence normative : ISO/IEC/IEEE 29119-3:2021

### Objet de la modification
- Ajouter le champ  à chaque entrée de  ( par défaut).
- Étendre Validation de standards/references.yaml OK pour exiger ce champ et vérifier sa valeur.
- Documenter cette règle dans README et CONTRIBUTING.

### Référence normative (OBLIGATOIRE si  ou  modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer . Utiliser les références listées dans .
- Source : ISO/IEC/IEEE 29119-3:2021
- Section/Clause/Entrée : Documentation (Part 3)
- Lien public / identifiant : https://www.iso.org/standard/79429.html

### Justification (résumé)
Préparer la gestion du cycle de vie des normes (#48) et faciliter la validation automatique.

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #48