### PR TITLE
docs(governance): create maintainer playbook

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,5 +38,6 @@ Cette page décrit les rôles, responsabilités et processus de décision pour l
 - `standards/glossaire-istqb.md` & `standards/cartographie-nfr-iso25010.md` : ressources de référence.
 - `standards/conventions-identifiants.md` : préfixes d’artefacts.
 - `docs/release-lifecycle.md` : cycle release, milestones, checklist.
+- `docs/maintainer-playbook.md` : routine mainteneurs, escalades.
 
 Toute évolution du processus doit être discutée via issue + PR associées. Lorsque des rôles supplémentaires sont nommés ou que les règles de revue évoluent, ce document constitue la référence officielle.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ce dépôt fournit des modèles de documentation de test alignés ISO/IEC/IEEE 2
   - `09-Rapport-Cloture-de-test.md` – bilan et critères de sortie.
 - `styles/` — configuration Vale (dictionnaire français, règles `Fr.Spelling`).
 - `standards/` — références normatives (`references.yaml`), glossaires (`glossaire-istqb.md`) et conventions (NFR `cartographie-nfr-iso25010.md`, identifiants `conventions-identifiants.md`).
-- `docs/` — guides (adoption, release lifecycle, etc.).
+- `docs/` — guides (adoption, release lifecycle, maintainer playbook, etc.).
 - `decisions/` — journal des Decision Records (DR) futur (#7, #30).
 
 ## Outillage & CI

--- a/docs/maintainer-playbook.md
+++ b/docs/maintainer-playbook.md
@@ -1,0 +1,66 @@
+# Maintainer Playbook
+
+Ce guide décrit la routine attendue pour les mainteneurs de **testing-templates**. Il complète `CONTRIBUTING.md`, `GOVERNANCE.md`, `docs/release-lifecycle.md` et `SECURITY.md`.
+
+## 1. Rythme de tri
+
+- **Quotidien** :
+  - Revue des issues nouvelles → vérifier DoR (#56) et priorité (#64, à venir).
+  - Vérifier les PR ouvertes (`gh pr status`), s’assurer que la CI a tourné.
+- **Hebdomadaire** :
+  - Audit du board (#63) : colonnes Backlog → Done.
+  - Revue des milestones (cf. `docs/release-lifecycle.md`).
+
+## 2. Gestion des issues
+
+1. Valider/compléter le DoR (commentaire standard).
+2. Appliquer les labels (`type`, `prio`, `scope`) – voir issue #55.
+3. Assigner un milestone si la cible est connue.
+4. Déplacer l’issue dans la colonne adaptée (Ready / In progress...).
+
+## 3. Gestion des PR
+
+- Vérifier :
+  - CI (`Docs CI`) = ✅.
+  - Bloc “Référence normative” rempli le cas échéant.
+  - Bloc “Sécurité” coché ou argumenté (PR template).
+- Revue : au moins 1 review mainteneur (cf. `GOVERNANCE.md`). Ajout d’un second reviewer si besoin.
+- Merge : squash par défaut, message conventionnel.
+- Post-merge :
+  - Supprimer la branche, `git pull --ff-only`.
+  - Ajouter un commentaire sur l’issue liée (progrès/CI).
+
+## 4. Cycle de release
+
+- Suivre `docs/release-lifecycle.md` :
+  - Vérifier l’avancement du milestone actif.
+  - Préparer la checklist RC (tests complémentaires, freeze).
+  - Générer notes de version et communication.
+- Compléter les DR si décisions structurantes (#7/#30).
+
+## 5. Escalade & sécurité
+
+- Vulnérabilités : appliquer `SECURITY.md` (réponse sous 3 jours ouvrés, suivi privé).
+- Bugs critiques :
+  - Créer issue P1 + milestone courant.
+  - Planifier hotfix si release en production.
+  - Documenter dans un DR si décision impact majeure.
+
+## 6. Outils
+
+- `gh pr status`, `gh issue status` (via board quand il sera configuré #54).
+- `scripts/validate_references.py` : vérifier lors de modifications (ex. `python3 scripts/validate_references.py`).
+- Vale (`shopt -s globstar && vale ...`) pour l’orthographe française.
+
+## 7. Contact & onboarding
+
+- Nouveaux mainteneurs : mettre à jour `GOVERNANCE.md` (table des rôles) et CODEOWNERS si nécessaire.
+- Communiquer via commentaires GitHub ou canal interne (à définir).
+
+## 8. Références
+
+- `GOVERNANCE.md`
+- `CONTRIBUTING.md`
+- `docs/release-lifecycle.md`
+- `SECURITY.md`
+- `standards/` (références, glossaire, cartographie NFR, conventions identifiants)

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4353
+4366
 A
 a
 AAAA-MM-JJ
@@ -4352,3 +4352,16 @@ utilisez
 inclure
 Inclure
 obligatoirement
+actif
+appliquer
+Appliquer
+colonnes
+connue
+conventionnel
+courant
+hotfix
+majeure
+nouvelles
+ouvertes
+rempli
+venir

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4351,3 +4351,16 @@ utilisez
 inclure
 Inclure
 obligatoirement
+actif
+appliquer
+Appliquer
+colonnes
+connue
+conventionnel
+courant
+hotfix
+majeure
+nouvelles
+ouvertes
+rempli
+venir


### PR DESCRIPTION
Référence normative : N/A (gouvernance interne)

### Objet de la modification
- Créer `docs/maintainer-playbook.md` décrivant la routine des mainteneurs (tri issues/PR, release lifecycle, escalade).
- Pointer vers ce playbook depuis README et GOVERNANCE.

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
- Source (ex. ISO/IEC/IEEE 29119-3:2021, ISO/IEC 25010:2023, IEEE 1012:2024, ISTQB Glossary, IREB) : N/A
- Section/Clause/Entrée : N/A
- Lien public / identifiant : N/A

### Justification (résumé)
Fournir un guide opérationnel aux mainteneurs (#58).

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #58
