### PR TITLE
docs: apply internal linking guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Ce guide décrit le flux complet pour proposer, cadrer, développer et fusionner
 
 - **Issue Forms** : fichiers YAML sous `.github/ISSUE_TEMPLATE/` imposent les champs DoR.
 - **Security** : pour signaler un problème, suivre `SECURITY.md`.
+- **Liens Markdown** : privilégier les liens relatifs vers les ressources internes (`templates/`, `standards/`, `docs/`). Utiliser l’URL officielle pour les normes externes (voir `standards/references.yaml`).
 - **PR Template** : `.github/PULL_REQUEST_TEMPLATE.md` avec bloc `Référence normative`.
 - **CI** : `.github/workflows/docs-ci.yml` (markdownlint + Vale + contrôle PR).
 - **Validation références** : `scripts/validate_references.py` (via Docs CI).   Inclure obligatoirement le champ `status` (ex.: `published`).

--- a/styles/Fr/dictionaries/fr.dic
+++ b/styles/Fr/dictionaries/fr.dic
@@ -1,4 +1,4 @@
-4366
+4367
 A
 a
 AAAA-MM-JJ
@@ -4365,3 +4365,4 @@ nouvelles
 ouvertes
 rempli
 venir
+relatifs

--- a/styles/config/vocabularies/Fr/accept.txt
+++ b/styles/config/vocabularies/Fr/accept.txt
@@ -4364,3 +4364,4 @@ nouvelles
 ouvertes
 rempli
 venir
+relatifs

--- a/templates/01-Strategie-de-test.md
+++ b/templates/01-Strategie-de-test.md
@@ -43,10 +43,10 @@ licence: "CC BY 4.0"
 
 * **Exigences / Backlog** : `<lien(s) JIRA/Squash/outil>`
 * **Politiques / normes internes** : `<sécurité, RGPD, accessibilité, qualité données…>`
-* **Plan de test** (02) : `<lien>`
-* **Conception de test** (03) : `<lien>`
-* **Cas de test** (04) : `<lien>`
-* **Procédures** (05) : `<lien>`
+* **Plan de test** (02) : `templates/02-Plan-de-test.md`
+* **Conception de test** (03) : `templates/03-Spec-Conception-de-test.md`
+* **Cas de test** (04) : `templates/04-Spec-Cas-de-test.md`
+* **Procédures** (05) : `templates/05-Spec-Procedures-de-test.md`
 * **Autres** : `<charte de dev, DoD, architecture>`
 
 ---

--- a/templates/02-Plan-de-test.md
+++ b/templates/02-Plan-de-test.md
@@ -43,10 +43,10 @@ licence: "CC BY 4.0"
 * Cartographie NFR : `standards/cartographie-nfr-iso25010.md`
 * Conventions d'identifiants : `standards/conventions-identifiants.md`
 
-* **Stratégie de test** (01) : `<lien>`
-* **Spécification de conception** (03) : `<lien>`
-* **Spécification des cas** (04) : `<lien>`
-* **Spécification des procédures** (05) : `<lien>`
+* **Stratégie de test** (01) : `templates/01-Strategie-de-test.md`
+* **Spécification de conception** (03) : `templates/03-Spec-Conception-de-test.md`
+* **Spécification des cas** (04) : `templates/04-Spec-Cas-de-test.md`
+* **Spécification des procédures** (05) : `templates/05-Spec-Procedures-de-test.md`
 * **Exigences / backlog** : `<lien(s) JIRA/Squash>`
 * **Politiques internes / conformité** : `<sécurité, RGPD, a11y, etc.>`
 * Glossaire ISTQB : `standards/glossaire-istqb.md`

--- a/templates/03-Spec-Conception-de-test.md
+++ b/templates/03-Spec-Conception-de-test.md
@@ -41,7 +41,7 @@ licence: "CC BY 4.0"
 
 * Exigences / User Stories : `<lien(s) référentiel : JIRA/Squash/…>`
 * Risques et criticités : `<lien(s) AMDEC / registre des risques>`
-* Stratégie / Plan de test : `<lien>`
+* Stratégie / Plan de test : `templates/01-Strategie-de-test.md`
 * Normes et référentiels : `ISO 29119-3`, `ISTQB Glossary`, `ISO 25010`, autres : `<…>`
 * Glossaire ISTQB : `standards/glossaire-istqb.md`
 * Cartographie NFR : `standards/cartographie-nfr-iso25010.md`

--- a/templates/04-Spec-Cas-de-test.md
+++ b/templates/04-Spec-Cas-de-test.md
@@ -39,7 +39,7 @@ licence: "CC BY 4.0"
 
 * Spécification de **conception** (conditions) : `<lien vers 03-Spec-Conception-de-test>`
 * Exigences / User Stories : `<lien(s) référentiel : JIRA/Squash/…>`
-* Stratégie / Plan de test : `<lien>`
+* Stratégie / Plan de test : `templates/01-Strategie-de-test.md`
 * Glossaire ISTQB : `standards/glossaire-istqb.md`
 * Cartographie NFR : `standards/cartographie-nfr-iso25010.md`
 * Normes et référentiels : `ISO 29119-3`, `ISTQB Glossary`, `ISO 25010`, autres : `<…>`

--- a/templates/05-Spec-Procédures-de-test.md
+++ b/templates/05-Spec-Procédures-de-test.md
@@ -40,7 +40,7 @@ licence: "CC BY 4.0"
 * Spécification de **conception** (conditions) : `<lien vers 03-Spec-Conception-de-test>`
 * Spécification de **cas de test** : `<lien vers 04-Spec-Cas-de-test>`
 * Exigences / User Stories : `<lien(s) référentiel : JIRA/Squash/…>`
-* Stratégie / Plan de test : `<lien>`
+* Stratégie / Plan de test : `templates/01-Strategie-de-test.md`
 * Normes et référentiels : `ISO 29119-3`, `ISTQB Glossary`, `ISO 25010`, autres : `<…>`
 
 ---

--- a/templates/06-Plan-Donnees-de-test.md
+++ b/templates/06-Plan-Donnees-de-test.md
@@ -38,9 +38,9 @@ licence: "CC BY 4.0"
 
 ## 2. Références
 
-* **Conception de test** (03) : `<lien>`
-* **Cas de test** (04) : `<lien>`
-* **Procédures** (05) : `<lien>`
+* **Conception de test** (03) : `templates/03-Spec-Conception-de-test.md`
+* **Cas de test** (04) : `templates/04-Spec-Cas-de-test.md`
+* **Procédures** (05) : `templates/05-Spec-Procedures-de-test.md`
 * **Politiques internes** : `<sécurité, RGPD, confidentialité, archivage>`
 * **Contrats / DPA / clauses** : `<si des données personnelles ou sous-traitants sont impliqués>`
 

--- a/templates/07-Exigences-Environnement-de-test.md
+++ b/templates/07-Exigences-Environnement-de-test.md
@@ -39,11 +39,11 @@ licence: "CC BY 4.0"
 
 ## 2. Références
 
-* **Stratégie (01)** : `<lien>`
-* **Plan de test (02)** : `<lien>`
-* **Conception (03)** : `<lien>`
-* **Cas (04) / Procédures (05)** : `<lien>`
-* **Plan de données (06)** : `<lien>`
+* **Stratégie (01)** : `templates/01-Strategie-de-test.md`
+* **Plan de test (02)** : `templates/02-Plan-de-test.md`
+* **Conception (03)** : `templates/03-Spec-Conception-de-test.md`
+* **Cas (04) / Procédures (05)** : `templates/04-Spec-Cas-de-test.md`, `templates/05-Spec-Procedures-de-test.md`
+* **Plan de données (06)** : `templates/06-Plan-Donnees-de-test.md`
 * **Politiques internes** : `<sécurité, backups, observabilité, RGPD, a11y>`
 
 ---

--- a/templates/08-Rapport-Statut-de-test.md
+++ b/templates/08-Rapport-Statut-de-test.md
@@ -51,8 +51,8 @@ licence: "CC BY 4.0"
 
 **Références.**
 
-* Stratégie (01) : `<lien>`
-* Plan de test (02) : `<lien>`
+* Stratégie (01) : `templates/01-Strategie-de-test.md`
+* Plan de test (02) : `templates/02-Plan-de-test.md`
 * Conception (03), Cas (04), Procédures (05) : `<liens>`
 * Plan Données (06) / Exigences Environnement (07) : `<liens>`
 


### PR DESCRIPTION
Référence normative : N/A (documentation interne)

### Objet de la modification
- Remplacer les placeholders `<lien>` par des liens relatifs vers les templates ou documents existants.
- Ajouter dans CONTRIBUTING une règle claire pour les liens Markdown (internes vs externes).

### Référence normative (OBLIGATOIRE si `templates/` ou `standards/` modifiés)
> Pour les PR tooling/CI/docs hors templates, indiquer `N/A`. Utiliser les références listées dans `standards/references.yaml`.
- Source : N/A
- Section/Clause/Entrée : N/A
- Lien public / identifiant : N/A

### Justification (résumé)
Harmoniser les liens Markdown afin de faciliter la navigation (#43).

### Impact sur les modèles
- [ ] Rupture (MAJOR)  [x] Ajout compatible (MINOR)  [ ] Correction (PATCH)

---

Closes #43
